### PR TITLE
Raise exception on file not found

### DIFF
--- a/date_integer_node.py
+++ b/date_integer_node.py
@@ -537,7 +537,7 @@ class VideoPathMetaExtraction:
     def process_video_file(self, video_file_path):
         # Check if the file exists
         if not os.path.exists(video_file_path):
-            return ("File not found", {})
+            raise Exception(f"File not found: {video_file_path}")
 
         # Extract metadata from the video
         metadata = self.extract_metadata(video_file_path)


### PR DESCRIPTION
Currently, if a file is not found, the String "File not found" is passed as output to the next node. This can make it particularly confusing to users since it hides which node was unable to find the file and doesn't provide information on what the incorrect file name is.

Instead, this pull request changes it to raise an error and provide the incorrect file name.

see kosinkadink/ComfyUI-VideoHelperSuite#114